### PR TITLE
Build crashed on an empty docstring. Fixed.

### DIFF
--- a/sphinx_autodoc_annotation.py
+++ b/sphinx_autodoc_annotation.py
@@ -62,13 +62,19 @@ def add_annotation_content(obj, result):
 class MyFunctionDocumenter(FunctionDocumenter):
     def get_doc(self, *args, **kwargs):
         result = super().get_doc(*args, **kwargs)
-        add_annotation_content(self.object, result[-1])
+        
+        if result:
+            add_annotation_content(self.object, result[-1])
+        
         return result
 
 class MyMethodDocumenter(MethodDocumenter):
     def get_doc(self, *args, **kwargs):
         result = super().get_doc(*args, **kwargs)
-        add_annotation_content(self.object, result[-1])
+        
+        if result:
+            add_annotation_content(self.object, result[-1])
+        
         return result
 
 def setup(app):


### PR DESCRIPTION
If an empty docstring was encountered, build would crash with IndexError (`result` was empty, so accessing its -1st element raised an error).

Additional checks added.
